### PR TITLE
Added optional variable to fix the spacing issue between the summary and attributes table in docs page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-endpoint-documentation",
   "description": "A component to generate documentation for a resource from AMF model",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -155,9 +155,6 @@ arc-marked {
 
 .method p {
   margin: 0;
-}
-
-method p {
   margin-bottom: var(--api-method-documentation-summary-p-margin-bottom,0)
 }
 

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -158,7 +158,7 @@ arc-marked {
 }
 
 method p {
-  margin-bottom: var(--api-method-documentation-summary-spacing,0)
+  margin-bottom: var(--api-method-documentation-summary-p-margin-bottom,0)
 }
 
 .method-name + p {

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -157,6 +157,10 @@ arc-marked {
   margin: 0;
 }
 
+method p {
+  margin-bottom: var(--api-method-documentation-summary-spacing,0)
+}
+
 .method-name + p {
   margin-top: 0.83em;
 }


### PR DESCRIPTION
Added optional variable to fix the spacing issue between the summary and attributes table in docs page. The additional variable is available as part of dsc repo. 