### PR TITLE
fix: update gRPC stream type display labels in ApiEndpointDocumentati…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/api-endpoint-documentation",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/api-endpoint-documentation",
-      "version": "6.1.3",
+      "version": "6.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-icons": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-endpoint-documentation",
   "description": "A component to generate documentation for a resource from AMF model",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiEndpointDocumentationElement.js
+++ b/src/ApiEndpointDocumentationElement.js
@@ -555,9 +555,15 @@ export class ApiEndpointDocumentationElement extends AmfHelperMixin(LitElement) 
       // If it's gRPC, add stream type information
       if (isGrpc && typeof this._getGrpcStreamType === 'function') {
         operationData.grpcStreamType = this._getGrpcStreamType(op);
-        operationData.grpcStreamTypeDisplay = typeof this._getGrpcStreamTypeDisplayName === 'function' 
-          ? this._getGrpcStreamTypeDisplayName(operationData.grpcStreamType)
-          : operationData.grpcStreamType;
+        
+        // Map stream type to simplified display labels (without "streaming")
+        const labelMap = {
+          'unary': 'UNARY',
+          'client_streaming': 'CLIENT',
+          'server_streaming': 'SERVER',
+          'bidi_streaming': 'BIDIRECTIONAL'
+        };
+        operationData.grpcStreamTypeDisplay = labelMap[operationData.grpcStreamType] || 'UNARY';
         
         // Map stream type to HTTP method for consistent colors
         const colorMethodMap = {

--- a/test/api-endpoint-documentation.test.js
+++ b/test/api-endpoint-documentation.test.js
@@ -532,8 +532,8 @@ describe('ApiEndpointDocumentationElement', () => {
           
           const firstLabel = methodLabels[0];
           const labelText = firstLabel.textContent.trim();
-          // The display name from AmfHelperMixin returns capitalized format (e.g., "Unary", "Client Streaming")
-          const validGrpcTypes = ['Unary', 'Client Streaming', 'Server Streaming', 'Bidirectional'];
+          // Simplified labels without "streaming" keyword
+          const validGrpcTypes = ['UNARY', 'CLIENT', 'SERVER', 'BIDIRECTIONAL'];
           const isValidGrpcType = validGrpcTypes.some(type => labelText.includes(type));
           assert.isTrue(isValidGrpcType, `should display a valid gRPC stream type, got: ${labelText}`);
         });


### PR DESCRIPTION
…onElement

- Modified the display logic for gRPC stream types to use simplified labels (UNARY, CLIENT, SERVER, BIDIRECTIONAL) instead of the previous capitalized format.
- Updated corresponding test cases to validate the new label format for gRPC stream types.